### PR TITLE
#30 change version alpine 3.19.2, doguctl 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#30] Update doguctl to v0.10.0
+- Update to Alpine 3.19.2
+
+### Security
+- this release closes the following CVEs
+  - CVE-2024-2511
+  - CVE-2024-4603
+  - CVE-2023-42363
+  - CVE-2023-42364
+  - CVE-2023-42365
+  - CVE-2023-42366
 
 ## [3.19.1-2] - 2024-06-06
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # keep variables beyond the single build stages, see https://stackoverflow.com/a/53682110/12529534
-ARG doguctl_version=0.10.0
+ARG doguctl_version=0.11.0
 
-ARG ALPINE_VER=3.19.1
-ARG ALPINE_VER_SHA=6457d53fb065d6f250e1504b9bc42d5b6c65941d57532c072d929dd0628977d0
+ARG ALPINE_VER=3.19.2
+ARG ALPINE_VER_SHA=af4785ccdbcd5cde71bfd5b93eabd34250b98651f19fe218c91de6c8d10e21c5
 
 FROM alpine:${ALPINE_VER}@sha256:${ALPINE_VER_SHA} as doguctlBinaryVerifier
 ARG doguctl_version
 
-ENV DOGUCTL_SHA256=2d1c9702813583a137a46c5d31a25957e26b32d7f0348f2531e5f76ef3cc39e2
+ENV DOGUCTL_SHA256=2b49d960e8d5abcb72fe5c621fd1ff9d248421d0bc0b58f4751e67125ecc64e0
 ENV DOGUCTL_VERSION=$doguctl_version
 RUN mkdir packages
 COPY packages/doguctl-$DOGUCTL_VERSION.tar.gz /packages


### PR DESCRIPTION
> [!CAUTION]
> Do not merge into develop but into the branch alpine 3.19 because this is an version re-release